### PR TITLE
Fix link of Bot Framework Composer docs

### DIFF
--- a/whats-new.md
+++ b/whats-new.md
@@ -65,7 +65,7 @@ Common Expression Language allows you to evaluate the outcome of a condition-bas
 [00]:http://docs.microsoft.com
 
 ### Bot Framework Composer (Preview)
-Bot Framework Composer is an integrated development tool for developers and multi-disciplinary teams to build bots and conversational experiences with the Microsoft Bot Framework. Within this tool, you'll find everything you need to build a sophisticated conversational experience. [[Docs](https://github.com/microsoft/BotFramework-Composer/tree/kaiqb/Ignite2019)]
+Bot Framework Composer is an integrated development tool for developers and multi-disciplinary teams to build bots and conversational experiences with the Microsoft Bot Framework. Within this tool, you'll find everything you need to build a sophisticated conversational experience. [[Docs](https://github.com/microsoft/BotFramework-Composer/blob/stable/toc.md)]
 
 ### Azure Bot Service
 - **Direct Line Speech (GA)**: Bot Framework and Microsoft's Speech Services provide a channel that enables streamed speech and text bi-directionally from the client to the bot application using WebSockets on Azure Bot Service. [[Docs](https://docs.microsoft.com/azure/bot-service/directline-speech-bot?view=azure-bot-service-4.0)] 


### PR DESCRIPTION
## Overview
I found the following link is the below 404.
So, I guess the correct link is "https://github.com/microsoft/BotFramework-Composer/blob/stable/toc.md".

If my understanding is right, please confirm this.

- Expiration link : https://github.com/microsoft/BotFramework-Composer/tree/kaiqb/Ignite2019
- Fix : https://github.com/microsoft/BotFramework-Composer/blob/stable/toc.md

![image](https://user-images.githubusercontent.com/20683785/68196287-b7fa0200-fffb-11e9-9a81-9bb39f10a055.png)

